### PR TITLE
Release: emergence-php-runtime v0.1.1

### DIFF
--- a/config/php-fpm.conf
+++ b/config/php-fpm.conf
@@ -1,7 +1,7 @@
 [global]
 daemonize                                      = off
 pid                                            = {{ pkg.svc_var_path }}/pid
-error_log                                      = {{ pkg.svc_var_path }}/error.log
+error_log                                      = {{ pkg.svc_var_path }}/logs/error.log
 
 [www]
 catch_workers_output                           = on

--- a/hooks/init
+++ b/hooks/init
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-mkdir -p "{{pkg.svc_var_path}}/logs"
-chown -R hab:hab "{{pkg.svc_var_path}}/logs"
+mkdir -p \
+    "{{pkg.svc_var_path}}/logs" \
+    "{{pkg.svc_var_path}}/site" \
+    "{{pkg.svc_var_path}}/site-data"
 
-{{#if cfg.site.holo.repo}}
-    mkdir -p "{{pkg.svc_var_path}}/site" "{{pkg.svc_var_path}}/site-data"
-    chown -R hab:hab "{{pkg.svc_var_path}}/site" "{{pkg.svc_var_path}}/site-data"
-{{/if}}
+chown -R hab:hab \
+    "{{pkg.svc_var_path}}/logs" \
+    "{{pkg.svc_var_path}}/site" \
+    "{{pkg.svc_var_path}}/site-data"


### PR DESCRIPTION
- fix: move php error.log logs to var/logs/
- fix: always initialize var/ subdirectories